### PR TITLE
:sparkles: 개발환경프록시설정 추가

### DIFF
--- a/src/shared/environment/env.ts
+++ b/src/shared/environment/env.ts
@@ -1,3 +1,4 @@
 export const ENV = {
   nodeEnv: import.meta.env,
+  baseUrl: import.meta.env.VITE_BASE_URL ?? "",
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,4 +6,13 @@ import react from "@vitejs/plugin-react-swc";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), tsConfigPaths()],
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://api.anycode.review:8080",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, "/api"), // URL 경로 재작성,
+      },
+    },
+  },
 });


### PR DESCRIPTION
# PR의 목적

로키가 CORS 설정을 해주지 않았습니다.

그래서 개발환경에서는 로키의 CORS를 우회하기 위하여 프록시 설정이 필요한 상태입니다.

따라서 vite에서 제공하는 프록시 설정을 통하여 브라우저의 CORS 에러를 우회합니다.

이 과정에서 기존 baseUrl을 사용하던것을 개발환경에 한하여 대체할 필요성이 있기 때문에 ENV 파일을 추가합니다.

.env.local
```
VITE_BASE_URL=""
```

혹시 환경변수 파일 쓰고싶으신 분은 이렇게 만들어서 루트에 두시면 되겠습니다.