### PR TITLE
공통 레이아웃 컴포넌트 적용

### DIFF
--- a/src/app/router/index.ts
+++ b/src/app/router/index.ts
@@ -1,0 +1,1 @@
+export * from "./router";

--- a/src/app/router/router.tsx
+++ b/src/app/router/router.tsx
@@ -1,6 +1,5 @@
 import { createBrowserRouter } from "react-router-dom";
 
-import { QuestionPage } from "~/pages/question";
 import { QuestionDetailPage } from "~/pages/question-detail-page/question-detail-page";
 import QuestionWritePage from "~/pages/question/question-write.page";
 import { ReumiPage } from "~/pages/reumi";
@@ -20,7 +19,6 @@ export const router = createBrowserRouter([
         path: ROUTE.questionDetail,
         element: <QuestionDetailPage />,
       },
-      { path: ROUTE.question, element: <QuestionPage /> },
       { path: ROUTE.questionWrite, element: <QuestionWritePage /> },
       { path: ROUTE.reumi, element: <ReumiPage /> },
     ],

--- a/src/app/router/router.tsx
+++ b/src/app/router/router.tsx
@@ -5,23 +5,19 @@ import QuestionWritePage from "~/pages/question/question-write.page";
 import { ReumiPage } from "~/pages/reumi";
 import { RootPage } from "~/pages/root";
 
+import { CommonLayout } from "~/widgets/common-layout";
+
 import { ROUTE } from "~/shared/route";
 
 export const router = createBrowserRouter([
   {
-    path: ROUTE.root,
-    element: <RootPage />,
-  },
-  {
-    path: ROUTE.question,
-    element: <QuestionPage />,
-  },
-  {
-    path: ROUTE.questionWrite,
-    element: <QuestionWritePage />,
-  },
-  {
-    path: ROUTE.reumi,
-    element: <ReumiPage />,
+    path: "/",
+    element: <CommonLayout />,
+    children: [
+      { path: ROUTE.root, element: <RootPage /> },
+      { path: ROUTE.question, element: <QuestionPage /> },
+      { path: ROUTE.questionWrite, element: <QuestionWritePage /> },
+      { path: ROUTE.reumi, element: <ReumiPage /> },
+    ],
   },
 ]);

--- a/src/entities/sidebar/ui/sidebar.ui.tsx
+++ b/src/entities/sidebar/ui/sidebar.ui.tsx
@@ -6,7 +6,6 @@ interface SidebarProps {
 }
 
 const Container = styled.div`
-  min-width: 168px;
   height: 429px;
   border-radius: 30px;
   display: flex;

--- a/src/features/question/question-write.feature.tsx
+++ b/src/features/question/question-write.feature.tsx
@@ -8,7 +8,6 @@ import { CategoryType } from "~/entities/question/model/question.type";
 import { QuestionWriteEditor } from "~/entities/question/ui";
 
 const QuestionContainer = styled.div`
-  margin: 20px 0;
   padding: 40px 20px;
   width: 768px;
   display: flex;
@@ -16,7 +15,6 @@ const QuestionContainer = styled.div`
   justify-content: center;
   align-items: center;
   gap: 40px;
-  background: rgb(42, 39, 49);
   background: linear-gradient(60deg, rgba(42, 39, 49, 1) 0%, rgba(137, 128, 155, 1) 35%, rgba(42, 39, 49, 1) 100%);
   border-radius: 28px;
   & > button {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
 import { GlobalSuspenseBoundary, ProviderList } from "~/app/provider";
-import { router } from "~/app/router/router";
+import { router } from "~/app/router";
 import "~/app/style/index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/pages/question-detail-page/question-detail-page.tsx
+++ b/src/pages/question-detail-page/question-detail-page.tsx
@@ -19,8 +19,6 @@ const QuestionTextContainer = styled.div`
 `;
 const QuestionBox = styled.div`
   width: 768px;
-  margin-left: auto;
-  margin-right: auto;
   box-sizing: border-box;
   padding: 20px;
   background: rgb(42, 39, 49);

--- a/src/pages/question/question-write.page.tsx
+++ b/src/pages/question/question-write.page.tsx
@@ -1,33 +1,12 @@
 import styled from "styled-components";
 
-import { Header } from "~/widgets/header";
-import { QuestionGuide } from "~/widgets/question-guide";
-import { Top } from "~/widgets/top-filter";
-
 import QuestionWrite from "~/features/question/question-write.feature";
 
 const QuestionWriteContainer = styled.div`
-  width: 100vw;
-  height: 100vh;
-  overflow-y: auto;
   scrollbar-width: none;
 `;
 
-const HeaderWrap = styled.div`
-  position: absolute;
-  top: 0;
-  width: 100%;
-  z-index: 10;
-  box-shadow: 0px 5px 10px rgba(117, 117, 121, 0.4);
-  background-color: ${({ theme }) => theme.colors.black};
-  & > div > * {
-    box-shadow: none;
-  }
-`;
-
 const QuestionWriteContent = styled.div`
-  margin-top: 172px;
-  padding-bottom: 120px;
   width: 100%;
   background-color: ${({ theme }) => theme.colors.black};
   box-shadow: inset 0 12px 200px ${({ theme }) => theme.colors.white}30;
@@ -44,26 +23,15 @@ const QuestionWriteContent = styled.div`
 
 const ContentWrap = styled.div`
   position: relative;
-`;
-const WriteSideBar = styled.div`
-  position: absolute;
-  top: 20px;
-  left: calc(100% + 20px);
+  background-color: black;
 `;
 
 const QuestionWritePage = () => {
   return (
     <QuestionWriteContainer>
-      <HeaderWrap>
-        <Header />
-        <Top isWritePage />
-      </HeaderWrap>
       <QuestionWriteContent>
         <ContentWrap>
           <QuestionWrite />
-          <WriteSideBar>
-            <QuestionGuide />
-          </WriteSideBar>
         </ContentWrap>
       </QuestionWriteContent>
     </QuestionWriteContainer>

--- a/src/pages/root/root.page.tsx
+++ b/src/pages/root/root.page.tsx
@@ -1,47 +1,5 @@
-import styled from "styled-components";
-
-import { Header } from "~/widgets/header";
-import { LanguageRank } from "~/widgets/language-rank";
-import { QuestionGuide } from "~/widgets/question-guide";
 import { QuestionList } from "~/widgets/question-list";
-import { ReviewerRank } from "~/widgets/reviewer-rank";
-import { Top } from "~/widgets/top-filter";
-
-import { Banner } from "~/shared/banner";
-
-const Main = styled.main`
-  width: 100%;
-  max-width: 1440px;
-  margin: auto;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  padding-top: 10px;
-`;
-
-const LeftSideBars = styled.section`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 30px;
-`;
 
 export const RootPage = () => {
-  return (
-    <>
-      <Header />
-      <Banner />
-      <Top />
-      <Main>
-        <LeftSideBars>
-          <ReviewerRank />
-          <LanguageRank />
-        </LeftSideBars>
-        {/* Todo: 사이드바 작업한 거랑 레이아웃 합쳐야함 */}
-        <QuestionList />
-        <QuestionGuide />
-      </Main>
-    </>
-  );
+  return <QuestionList />;
 };

--- a/src/shared/banner/banner.tsx
+++ b/src/shared/banner/banner.tsx
@@ -1,6 +1,8 @@
 import { styled } from "styled-components";
 
-const Warpper = styled.div`
+import bannerImg from "~/shared/icons/main/banner.png";
+
+const Wrapper = styled.div`
   width: 100%;
   max-width: 1440px;
   margin: auto;
@@ -14,8 +16,8 @@ const Img = styled.img`
 
 export const Banner = () => {
   return (
-    <Warpper>
-      <Img src="src/shared/icons/main/banner.png" alt="" />
-    </Warpper>
+    <Wrapper>
+      <Img src={bannerImg} alt="banner" />
+    </Wrapper>
   );
 };

--- a/src/widgets/common-layout/common-layout.tsx
+++ b/src/widgets/common-layout/common-layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import styled from "styled-components";
 
 import { Banner } from "~/shared/banner";
@@ -21,6 +21,7 @@ const Main = styled.main`
 `;
 
 const LeftSideBars = styled.section`
+  min-width: 184px;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -29,6 +30,10 @@ const LeftSideBars = styled.section`
 `;
 
 export const CommonLayout = () => {
+  const location = useLocation();
+
+  const isWritePage = location.pathname === "/question/write";
+
   return (
     <>
       <Header />
@@ -36,8 +41,12 @@ export const CommonLayout = () => {
       <Top />
       <Main>
         <LeftSideBars>
-          <ReviewerRank />
-          <LanguageRank />
+          {!isWritePage && (
+            <>
+              <ReviewerRank />
+              <LanguageRank />
+            </>
+          )}
         </LeftSideBars>
         <Outlet />
         <QuestionGuide />

--- a/src/widgets/common-layout/common-layout.tsx
+++ b/src/widgets/common-layout/common-layout.tsx
@@ -1,0 +1,47 @@
+import { Outlet } from "react-router-dom";
+import styled from "styled-components";
+
+import { Banner } from "~/shared/banner";
+
+import { Header } from "../header";
+import { LanguageRank } from "../language-rank";
+import { QuestionGuide } from "../question-guide";
+import { ReviewerRank } from "../reviewer-rank";
+import { Top } from "../top-filter";
+
+const Main = styled.main`
+  width: 100%;
+  max-width: 1440px;
+  margin: auto;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 10px;
+  gap: 10px;
+`;
+
+const LeftSideBars = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 30px;
+`;
+
+export const CommonLayout = () => {
+  return (
+    <>
+      <Header />
+      <Banner />
+      <Top />
+      <Main>
+        <LeftSideBars>
+          <ReviewerRank />
+          <LanguageRank />
+        </LeftSideBars>
+        <Outlet />
+        <QuestionGuide />
+      </Main>
+    </>
+  );
+};

--- a/src/widgets/common-layout/index.ts
+++ b/src/widgets/common-layout/index.ts
@@ -1,0 +1,1 @@
+export * from "./common-layout";

--- a/src/widgets/top-filter/ui/top.ui.tsx
+++ b/src/widgets/top-filter/ui/top.ui.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 
 import { QuestionButton } from "~/entities/question-button";
@@ -18,7 +19,10 @@ const Wrapper = styled.div`
   }
 `;
 
-export const Top = ({ isWritePage = false }: { isWritePage?: boolean }) => {
+export const Top = () => {
+  const location = useLocation();
+  const isWritePage = location.pathname === "/question/write";
+
   return (
     <Wrapper>
       <QuestionListFilter />


### PR DESCRIPTION
### 작업 내용
- 헤더와 사이드 바 컴포넌트가 항상 공통으로 사용되기 때문에 불필요하게 매번 불러와서 사용하고 스타일 작업 하지 않도록
모든 페이지에 적용될 수 있도록 개선했습니다.
- 공통 컴포넌트로 적용하면서 틀어지는 스타일 또한 맞게 수정했습니다.
